### PR TITLE
Initialize asciidoctor.js only once

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,22 @@ var through = require('through-gulp');
 var gutil = require('gulp-util');
 var asciidoctorJs = require('asciidoctor.js')();
 var opal = asciidoctorJs.Opal;
+var processor = asciidoctorJs.Asciidoctor(true);
 
 module.exports = function(options) {
+    // default config
+    options = options || {};
+    options.base_dir = options.base_dir || process.cwd();
+    options.safe = options.safe || 'secured';
+    options.doctype = options.doctype || 'html';
+    options.header_footer = options.header_footer || true;
+    options.attributes = options.attributes || ['showtitle'];
+
+    var optionsOpal = opal.hash2(
+      ['base_dir', 'safe', 'doctype', 'header_footer',
+          'attributes'
+      ], options);
+
     // creating a stream through which each file will pass
     var stream = through(function(file, encoding, callback) {
         // do whatever necessary to process the file 
@@ -25,22 +39,6 @@ module.exports = function(options) {
 
         // just pipe data next, or just do nothing to process file later in flushFunction
         // never forget callback to indicate that the file has been processed.
-
-        var processor = asciidoctorJs.Asciidoctor(true);
-
-        //default config
-        options = options || {};
-        options.base_dir = options.base_dir || process.cwd();
-        options.safe = options.safe || 'secured';
-        options.doctype = options.doctype || 'html';
-        options.header_footer = options.header_footer || true;
-        options.attributes = options.attributes || ['showtitle'];
-
-
-        var optionsOpal = opal.hash2(
-            ['base_dir', 'safe', 'doctype', 'header_footer',
-                'attributes'
-            ], options);
 
         var data = processor.$convert(file.contents.toString(),
             optionsOpal);


### PR DESCRIPTION
Without this, only the first file works, subsequent streams fail:

```
[22:38:27] ArgumentError: illegal key name: block_terminates_paragraph
    at OpalClass.def.$backtrace.self [as $new] (docs/node_modules/gulp-asciidoctor/node_modules/asciidoctor.js/node_modules/opal-npm-wrapper/index.j
s:2783:17)
    at OpalModule.def.$raise (docs/node_modules/gulp-asciidoctor/node_modules/asciidoctor.js/node_modules/opal-npm-wrapper/index.js:2434:31)
    at OpalModule.a.cdecl.c [as $define] (docs/node_modules/gulp-asciidoctor/node_modules/asciidoctor.js/dist/npm/asciidoctor-core.min.js:10:5996)
    at a.cdecl.c (docs/node_modules/gulp-asciidoctor/node_modules/asciidoctor.js/dist/npm/asciidoctor-core.min.js:10:6233)
    at b (docs/node_modules/gulp-asciidoctor/node_modules/asciidoctor.js/dist/npm/asciidoctor-core.min.js:10:6601)
    at docs/node_modules/gulp-asciidoctor/node_modules/asciidoctor.js/dist/npm/asciidoctor-core.min.js:10:31491
    at Object.Asciidoctor (docs/node_modules/gulp-asciidoctor/node_modules/asciidoctor.js/dist/npm/asciidoctor-core.min.js:10:31548)
    at module.exports (docs/node_modules/gulp-asciidoctor/index.js:8:33)
    at Gulp.<anonymous> (docs/gulpfile.js:28:11)
    at module.exports (docs/node_modules/gulp/node_modules/orchestrator/lib/runTask.js:34:7)
```
