### PR TITLE
Changed the way options are handled

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,17 +6,16 @@ var opal = asciidoctorJs.Opal;
 var processor = asciidoctorJs.Asciidoctor(true);
 
 module.exports = function (options) {
+    options = options || {};
+
     // default config
     var asciidoctorOptions = {};
 
-    asciidoctorOptions.base_dir = options.base_dir || process.cwd();
+    asciidoctorOptions.base_dir = options.baseDir || options.base_dir || process.cwd();
     asciidoctorOptions.safe = options.safe || 'secured';
     asciidoctorOptions.doctype = options.doctype || 'article';
     asciidoctorOptions.attributes = options.attributes || ['showtitle'];
-    asciidoctorOptions.header_footer = true;
-    if (typeof options.header_footer !== 'undefined') { // the variable is defined
-        asciidoctorOptions.header_footer = !!options.header_footer;
-    }
+    asciidoctorOptions.header_footer = (options.headerFooter === undefined ? true : options.headerFooter);
 
     var optionsOpal = opal.hash2(
         ['base_dir', 'safe', 'doctype', 'header_footer',


### PR DESCRIPTION
Added "options = options || {}" to avoid "undefined <property>" errors when you don't pass arguments to gulp-asciidoctor and changed some option names to be more correct (base_dir to baseDir and header_footer to headerFooter).
